### PR TITLE
fixed low hanging fruit

### DIFF
--- a/assembler/ndisasm.c
+++ b/assembler/ndisasm.c
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
 		p++;
 		break;
 	      case 'h':
-		fprintf(stderr, help);
+		fprintf(stderr, "%s", help);
 		return 0;
 	      case 'r':
               case 'v':

--- a/assembler/output/outieee.c
+++ b/assembler/output/outieee.c
@@ -1102,7 +1102,7 @@ static void ieee_putascii(char *format, ...)
 		if ((buffer[i] & 0xff) > 31)
 			checksum+=buffer[i];
 	va_end(ap);
-	fprintf(ofp,buffer);
+	fprintf(ofp,"%s",buffer);
 }
 
 /*

--- a/compiler/config.h
+++ b/compiler/config.h
@@ -222,7 +222,7 @@
  *	 NOTE: This must be a signed value.
  */
 #define	STP_PTRDIFF	stp_int		/* ptrdiff_t type; either stp_int or stp_long */
-								/* 8086 Needs 16-bit pointers. -WSF /*
+								/* 8086 Needs 16-bit pointers. -WSF */
 
 /*
  *	The type of a wide character is implementation defined and has an

--- a/compiler/gen86.c
+++ b/compiler/gen86.c
@@ -1553,7 +1553,7 @@ static ADDRESS *g_shift P3 (const EXPR *, ep, FLAGS, flags, OPCODE, op)
 static ADDRESS *g_asshift P3 (const EXPR *, ep, FLAGS, flags, OPCODE, op)
 {
     ADDRESS *ap1, *ap2;
-    EXPR   *ep1;    FLAGS   flgs;   // Added for new code below - WSF
+    FLAGS   flgs;   // Added for new code below - WSF
 
 
     switch (ep->etp->type) {
@@ -1578,9 +1578,8 @@ static ADDRESS *g_asshift P3 (const EXPR *, ep, FLAGS, flags, OPCODE, op)
 	// code for the 8086 (i.e., uses an immediate operand). The code was 
 	// taken from the g_shift() function. - WSF
 	ap1 = g_expr (ep->v.p[0], (FLAGS) (F_DREG | F_VOL | F_NOECX));
-	ep1 = ep->v.p[1];
-		flgs = (FLAGS) (F_DREG | F_ECX);
-	    ap2 = g_expr (ep->v.p[1], flgs);
+	flgs = (FLAGS) (F_DREG | F_ECX);
+	ap2 = g_expr (ep->v.p[1], flgs);
 	validate (ap1);
 	g_code (op, (ILEN) ep->etp->size, ap2, ap1);
 	freeop (ap2);

--- a/compiler/outx86_n.c
+++ b/compiler/outx86_n.c
@@ -1254,17 +1254,16 @@ PRIVATE void put_rseg P1 (SIZE, al)
     put_cseg (al);
 }
 
+/*	The following isn't supported by NASM. -WSF
 static void put_noseg P0 (void)
 {
-	/*	The following isn't supported by NASM. -WSF
     nl ();
     if (curseg != noseg) {
 	curseg = noseg;
 	align_type = 0L;
 	oprintf ("\tassume\tds:nothing%s", newline);
     }
-	*/
-}
+}*/
 
 PRIVATE void put_finish P0 (void)
 {

--- a/emulator/NasmDisassemble/nasm_disasm.cpp
+++ b/emulator/NasmDisassemble/nasm_disasm.cpp
@@ -517,12 +517,12 @@ long disasm (unsigned char *data, char *output, int segsize, long offset,
 	else if (*data == 0x2E || *data == 0x36 || *data == 0x3E ||
 		 *data == 0x26 || *data == 0x64 || *data == 0x65) {
 	    switch (*data++) {
-	      case 0x2E: segover = "cs"; break;
-	      case 0x36: segover = "ss"; break;
-	      case 0x3E: segover = "ds"; break;
-	      case 0x26: segover = "es"; break;
-	      case 0x64: segover = "fs"; break;
-	      case 0x65: segover = "gs"; break;
+	      case 0x2E: segover = (char *)"cs"; break;
+	      case 0x36: segover = (char *)"ss"; break;
+	      case 0x3E: segover = (char *)"ds"; break;
+	      case 0x26: segover = (char *)"es"; break;
+	      case 0x64: segover = (char *)"fs"; break;
+	      case 0x65: segover = (char *)"gs"; break;
 	    }
 	} else if (*data == 0x66)
 	    osize = 48 - segsize, data++;

--- a/emulator/SimWindow.cpp
+++ b/emulator/SimWindow.cpp
@@ -48,7 +48,7 @@ bool CSimWindow::InitWindow(void)
 // For printing normal strings. It supports \n, \r, \t, and \b correctly.
 void CSimWindow::PrintText(const char *string)
 {
-	printf(string);
+	printf("%s", string);
 }
 
 
@@ -90,7 +90,7 @@ int CSimWindow::GetHistory(int dir, char *dest, int clearChars)
 	// Copy command from history
 	strcpy(dest, string);
 	i = strlen(string);
-	printf(string);
+	printf("%s", string);
 	
 	return i;
 }

--- a/emulator/ops2.cpp
+++ b/emulator/ops2.cpp
@@ -88,68 +88,68 @@ void x86emuOp2_long_jump(u8 op2)
     START_OF_INSTR();
     switch (op2) {
       case 0x80:
-        name = "JO\t";
+        name = (char *)"JO\t";
         cond =  ACCESS_FLAG(F_OF);
         break;
       case 0x81:
-        name = "JNO\t";
+        name = (char *)"JNO\t";
         cond = !ACCESS_FLAG(F_OF);
         break;
       case 0x82:
-        name = "JB\t";
+        name = (char *)"JB\t";
         cond = ACCESS_FLAG(F_CF);
         break;
       case 0x83:
-        name = "JNB\t";
+        name = (char *)"JNB\t";
         cond = !ACCESS_FLAG(F_CF);
         break;
       case 0x84:
-        name = "JZ\t";
+        name = (char *)"JZ\t";
         cond = ACCESS_FLAG(F_ZF);
         break;
       case 0x85:
-        name = "JNZ\t";
+        name = (char *)"JNZ\t";
         cond = !ACCESS_FLAG(F_ZF);
         break;
       case 0x86:
-        name = "JBE\t";
+        name = (char *)"JBE\t";
         cond = ACCESS_FLAG(F_CF) || ACCESS_FLAG(F_ZF);
         break;
       case 0x87:
-        name = "JNBE\t";
+        name = (char *)"JNBE\t";
         cond = !(ACCESS_FLAG(F_CF) || ACCESS_FLAG(F_ZF));
         break;
       case 0x88:
-        name = "JS\t";
+        name = (char *)"JS\t";
         cond = ACCESS_FLAG(F_SF);
         break;
       case 0x89:
-        name = "JNS\t";
+        name = (char *)"JNS\t";
         cond = !ACCESS_FLAG(F_SF);
         break;
       case 0x8a:
-        name = "JP\t";
+        name = (char *)"JP\t";
         cond = ACCESS_FLAG(F_PF);
         break;
       case 0x8b:
-        name = "JNP\t";
+        name = (char *)"JNP\t";
         cond = !ACCESS_FLAG(F_PF);
         break;
       case 0x8c:
-        name = "JL\t";
+        name = (char *)"JL\t";
         cond = xorl(ACCESS_FLAG(F_SF), ACCESS_FLAG(F_OF));
         break;
       case 0x8d:
-        name = "JNL\t";
+        name = (char *)"JNL\t";
         cond = xorl(ACCESS_FLAG(F_SF), ACCESS_FLAG(F_OF));
         break;
       case 0x8e:
-        name = "JLE\t";
+        name = (char *)"JLE\t";
         cond = (xorl(ACCESS_FLAG(F_SF), ACCESS_FLAG(F_OF)) ||
                 ACCESS_FLAG(F_ZF));
         break;
       case 0x8f:
-        name = "JNLE\t";
+        name = (char *)"JNLE\t";
         cond = !(xorl(ACCESS_FLAG(F_SF), ACCESS_FLAG(F_OF)) ||
                  ACCESS_FLAG(F_ZF));
         break;
@@ -180,68 +180,68 @@ void x86emuOp2_set_byte(u8 op2)
     START_OF_INSTR();
     switch (op2) {
       case 0x90:
-        name = "SETO\t";
+        name = (char *)"SETO\t";
         cond =  ACCESS_FLAG(F_OF);
         break;
       case 0x91:
-        name = "SETNO\t";
+        name = (char *)"SETNO\t";
         cond = !ACCESS_FLAG(F_OF);
         break;
       case 0x92:
-        name = "SETB\t";
+        name = (char *)"SETB\t";
         cond = ACCESS_FLAG(F_CF);
         break;
       case 0x93:
-        name = "SETNB\t";
+        name = (char *)"SETNB\t";
         cond = !ACCESS_FLAG(F_CF);
         break;
       case 0x94:
-        name = "SETZ\t";
+        name = (char *)"SETZ\t";
         cond = ACCESS_FLAG(F_ZF);
         break;
       case 0x95:
-        name = "SETNZ\t";
+        name = (char *)"SETNZ\t";
         cond = !ACCESS_FLAG(F_ZF);
         break;
       case 0x96:
-        name = "SETBE\t";
+        name = (char *)"SETBE\t";
         cond = ACCESS_FLAG(F_CF) || ACCESS_FLAG(F_ZF);
         break;
       case 0x97:
-        name = "SETNBE\t";
+        name = (char *)"SETNBE\t";
         cond = !(ACCESS_FLAG(F_CF) || ACCESS_FLAG(F_ZF));
         break;
       case 0x98:
-        name = "SETS\t";
+        name = (char *)"SETS\t";
         cond = ACCESS_FLAG(F_SF);
         break;
       case 0x99:
-        name = "SETNS\t";
+        name = (char *)"SETNS\t";
         cond = !ACCESS_FLAG(F_SF);
         break;
       case 0x9a:
-        name = "SETP\t";
+        name = (char *)"SETP\t";
         cond = ACCESS_FLAG(F_PF);
         break;
       case 0x9b:
-        name = "SETNP\t";
+        name = (char *)"SETNP\t";
         cond = !ACCESS_FLAG(F_PF);
         break;
       case 0x9c:
-        name = "SETL\t";
+        name = (char *)"SETL\t";
         cond = xorl(ACCESS_FLAG(F_SF), ACCESS_FLAG(F_OF));
         break;
       case 0x9d:
-        name = "SETNL\t";
+        name = (char *)"SETNL\t";
         cond = xorl(ACCESS_FLAG(F_SF), ACCESS_FLAG(F_OF));
         break;
       case 0x9e:
-        name = "SETLE\t";
+        name = (char *)"SETLE\t";
         cond = (xorl(ACCESS_FLAG(F_SF), ACCESS_FLAG(F_OF)) ||
                 ACCESS_FLAG(F_ZF));
         break;
       case 0x9f:
-        name = "SETNLE\t";
+        name = (char *)"SETNLE\t";
         cond = !(xorl(ACCESS_FLAG(F_SF), ACCESS_FLAG(F_OF)) ||
                  ACCESS_FLAG(F_ZF));
         break;


### PR DESCRIPTION
This fixes quite a few compiler warnings. A lot of them were improper use of the format string in printf functions... which is actually a security risk (https://stackoverflow.com/questions/7459630/how-can-a-format-string-vulnerability-be-exploited)