### PR TITLE
Fixing emulator for Ubuntu 17.04 and 17.10

### DIFF
--- a/emulator/prim_ops.cpp
+++ b/emulator/prim_ops.cpp
@@ -2348,7 +2348,7 @@ void div_byte(u8 s)
     }
 	div = dvd / (u8)s;
 	mod = dvd % (u8)s;
-	if (abs(div) > 0xff) {
+	if (div > 0xff) {
 		x86emu_intr_raise(0);
         return;
 	}
@@ -2371,7 +2371,7 @@ void div_word(u16 s)
     }
 	div = dvd / (u16)s;
 	mod = dvd % (u16)s;
-	if (abs(div) > 0xffff) {
+	if (div > 0xffff) {
 		x86emu_intr_raise(0);
 		return;
 	}
@@ -2400,7 +2400,7 @@ void div_long(u32 s)
 	}
 	div = dvd / (u32)s;
 	mod = dvd % (u32)s;
-	if (abs(div) > 0xffffffff) {
+	if (div > 0xffffffff) {
 		x86emu_intr_raise(0);
 		return;
 	}

--- a/readme.md
+++ b/readme.md
@@ -22,10 +22,20 @@ There are a few dependencies needed for this toolchain to be built correctly.
 On Debian based systems (Ubuntu, etc), run the following in your terminal:
 
 ```bash
-sudo apt-get install gcc-multilib g++-multilib libc6-dev-i386 lib32ncurses5-dev
+sudo apt-get install gcc-multilib g++-multilib libc6-dev-i386 lib32ncurses5-dev xterm
 ```
 
-*Tested on Ubuntu 16.04 x86_64.*
+If on Ubuntu 17.04 or higher, you may get the following error:
+
+```bash
+xterm: cannot load font '-misc-fixed-medium-r-semicondensed--13-120-75-75-c-60-iso10646-1'
+```
+
+emu86 will still work fine, however, if the error is annoying then
+try following the steps in this form:
+http://forum.porteus.org/viewtopic.php?f=53&t=1013
+
+*Tested on Ubuntu 16.04 x86_64, Ubuntu 17.04 x86_64 & Ubuntu 17.10*
 
 **Prerequisites for Mac OS X:**
 

--- a/readme.md
+++ b/readme.md
@@ -25,16 +25,6 @@ On Debian based systems (Ubuntu, etc), run the following in your terminal:
 sudo apt-get install gcc-multilib g++-multilib libc6-dev-i386 lib32ncurses5-dev xterm
 ```
 
-If on Ubuntu 17.04 or higher, you may get the following error:
-
-```bash
-xterm: cannot load font '-misc-fixed-medium-r-semicondensed--13-120-75-75-c-60-iso10646-1'
-```
-
-emu86 will still work fine, however, if the error is annoying then
-try following the steps in this form:
-http://forum.porteus.org/viewtopic.php?f=53&t=1013
-
 *Tested on Ubuntu 16.04 x86_64, Ubuntu 17.04 x86_64 & Ubuntu 17.10*
 
 **Prerequisites for Mac OS X:**
@@ -80,6 +70,8 @@ This will actually add your toolchain bin to the path.
 **Linux:**
 + `cdefs` not defined: Make sure Linux prereqs are installed
 + Parsing errors with Perl generated headers/macros: At some point the files were saved with 'DOS' line endings instead of Unix, so if you see a `^M` (Windows carriage return char) that is likely the issue and saving (or overwriting) the file correctly should fix it. Make sure to blow away any generated files.
++ If on Ubuntu 17.04 or higher, you may get the following error: `xterm: cannot load font '-misc-fixed-medium-r-semicondensed--13-120-75-75-c-60-iso10646-1'`. emu86 will still work fine. If you wish to fix the error, you can try following the steps in this form:  http://forum.porteus.org/viewtopic.php?f=53&t=1013
+
 
 **Mac:**
 + `cpp` does not remove `//` comments correctly: See Makefile example below, make sure to add `-xc++` flag to `cpp` to remove c99 style comments.


### PR DESCRIPTION
The updated g++ and gcc libraries included in Ubuntu 17.04 and up don't handle the absolute value function for an unsigned value. Also, the distro no longer comes bundled with xterm and has a few more installation steps.